### PR TITLE
Test for creation of sample nodefetch.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,20 @@
 {
-    "name": "nodefetch",
-    "version": "0.0.4",
-    "description": "Fetch popular web libraries from the net",
-    "preferGlobal": "true",
-    "bin": { "nodefetch": "nodefetch.js" },
-    "author": "Jack Franklin",
-    "engines": { "node": "*" },
-    "repository": {
-      "type" : "git",
-      "url" : "git@github.com:jackfranklin/nodefetch.git"
-    }
+  "name": "nodefetch",
+  "version": "0.0.4",
+  "description": "Fetch popular web libraries from the net",
+  "preferGlobal": "true",
+  "bin": {
+    "nodefetch": "nodefetch.js"
+  },
+  "author": "Jack Franklin",
+  "engines": {
+    "node": "*"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:jackfranklin/nodefetch.git"
+  },
+  "dependencies": {
+    "shelljs": "0.0.6"
+  }
 }

--- a/test/coarse.js
+++ b/test/coarse.js
@@ -1,0 +1,37 @@
+var assert = require("assert");
+var shell  = require('shelljs');
+var path   = require('path');
+
+// JANKY.  Assumes the nodefetch is globally installed on the machine
+// that a test is running
+describe('nodefetch', function(){
+
+  var home     = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
+  var settings = path.join(home, "nodefetch.json");
+  var temp     = path.join(home, "_nodefetch.json.tmp");
+
+  describe("settings file", function(){
+    before(function(){
+      // if a global settings file exists we need to stash
+      if(shell.test('-f', settings)){
+        shell.mv(settings, temp);
+      }
+    });
+
+    it("should fetch a default file when no settings are present", function(){
+      shell.exec('nodefetch')
+      assert(shell.test('-f', settings));
+    });
+
+    after(function(){
+      // remove the newly created settings file
+      shell.rm(settings);
+
+      // if the originall stashed we need to move that file back
+      if(shell.test('-f', temp)){
+        shell.mv(temp, settings);
+      }
+    });
+
+  });
+});


### PR DESCRIPTION
Jack,

As discussed this pull request should cover a fairly straightforward way of testing nodefetch in a very coarse grained manner.  The test suite assumes the nodefetch is globally installed on the test machine (this is a horrible assumption for a test to be fair.  I've done this because currently the `nodefetch.js` script doesn't like being `required` within another script (the settings file doesn't get pulled down in a timely fashion).  I didn't investigate further as you plan on a fair bit of refactoring (commander/shelljs).

I wouldn't do too many of these sorts of tests as in comparison to bare unit tests they are rather messy (touching the file system, reaching out to the interwebz etc.).

I'll get more in when I get a chance.
