### PR TITLE
Detect if the search term is a URL, and immediately call back if it is.

### DIFF
--- a/pulldown.js
+++ b/pulldown.js
@@ -96,6 +96,10 @@ Pulldown.prototype.processUserArgs = function(callback) {
 };
 
 Pulldown.prototype.parsePackageArgument = function(searchTerm, callback) {
+  if(isUrl(searchTerm)) {
+    callback({ url: searchTerm });
+    return;
+  }
   var split = searchTerm.split(":");
   var outputName;
   if (split.length > 1) {


### PR DESCRIPTION
This is a temporary fix to allow URL d/ling to work.

I think we spoke about this before, but we should change the delimiter from `:` to something that wont ever be in a URL (`|`, or `::` ? ), and then we can easily support downloading a URL to a specific output.
