### PR TITLE
add basic tab completion

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -9,6 +9,8 @@ var URL            = require("url");
 var pulldown       = require("../pulldown");
 var pkg            = require("../package.json");
 var argv           = require("optimist").boolean(["d", "dry-run"]).argv;
+var tabtab         = require('tabtab');
+var request        = require('request');
 
 pulldown.on('resolved', function (identifier, result) {
   if (!cli.noisy) return;
@@ -146,12 +148,22 @@ var cli = {
     if(notifier.update) {
       notifier.notify();
     };
+  },
+  completion: function() {
+    return tabtab.complete('pulldown', function (err, data) {
+      if( err || !data ) { return; }
+
+      return tabtab.log(['marionette', 'underscore', 'backbone', 'html5shiv'], data);
+    });
   }
 };
 
 module.exports = cli;
 
 if(require.main == module) {
+  if(argv._[0] === 'completion') {
+    return cli.completion();
+  }
   cli.run(argv);
 }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "underscore": "~1.4.4",
     "chalk": "~0.2.0",
     "update-notifier": "~0.1.5",
-    "optimist": "~0.6.0"
+    "optimist": "~0.6.0",
+    "tabtab": "0.0.2"
   },
   "devDependencies": {
     "mocha": "~1.10.0",


### PR DESCRIPTION
Related to #80.

This is **not** ready to merge, but I added a proof of concept tab completion to Pulldown. Just add `. <(pulldown completion)` to your bash/zsh config file.

@phuu if we could get (and cache) a list of all packages on CDNJS, that would be good if we could offer tab completion on all of those. As long as we cache the list and don't make the request every time.
